### PR TITLE
Update ios/Podfile to work with Cocoapods 1.5

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -29,9 +29,8 @@ end
 target 'Runner' do
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
-  system('rm -rf Pods/.symlinks')
-  system('mkdir -p Pods/.symlinks/flutter')
-  system('mkdir -p Pods/.symlinks/plugins')
+  system('rm -rf .symlinks')
+  system('mkdir -p .symlinks/plugins')
 
   # Flutter Pods
   generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
@@ -40,16 +39,16 @@ target 'Runner' do
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
-      symlink = File.join('Pods', '.symlinks', 'flutter', File.basename(p[:path]))
-      File.symlink(p[:path], symlink)
-      pod 'Flutter', :path => symlink
+      symlink = File.join('.symlinks', 'flutter')
+      File.symlink(File.dirname(p[:path]), symlink)
+      pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
     end
   }
 
   # Plugin Pods
   plugin_pods = parse_KV_file('../.flutter-plugins')
   plugin_pods.map { |p|
-    symlink = File.join('Pods', '.symlinks', 'plugins', File.basename(p[:path]))
+    symlink = File.join('.symlinks', 'plugins', p[:name])
     File.symlink(p[:path], symlink)
     pod p[:name], :path => File.join(symlink, 'ios')
   }


### PR DESCRIPTION
Fixes `"Flutter/Flutter.h not found." on iOS` build failures on recent builds. 

See https://github.com/flutter/flutter/issues/16036 for conversation about the error, and https://github.com/flutter/flutter/pull/16273 for the fix.
