### PR TITLE
Set maxWidth and maxHeight on pickImage()

### DIFF
--- a/lib/upload_page.dart
+++ b/lib/upload_page.dart
@@ -153,7 +153,7 @@ class _Uploader extends State<Uploader> {
                 onPressed: () async {
                   Navigator.pop(context);
                   File imageFile =
-                      await ImagePicker.pickImage(source: ImageSource.camera);
+                      await ImagePicker.pickImage(source: ImageSource.camera, maxWidth: 1920, maxHeight: 1350);
                   setState(() {
                     file = imageFile;
                   });


### PR DESCRIPTION
If you don't do that, many devices won't show image thumbnail after taking picture with the native camera using rear view (because of the resolution / size is too big).

https://dustinstout.com/instagram-sizes/

"For Instagram landscape images, the smallest I have tested on was at 1920×1080 which Instagram then displayed at 600×337. As it turns out, though, Instagram ended up storing a version that is 1080×607."

"Vertical images (or portrait) will display at a maximum of 480×600 (or 960×1200 for retina display). However it looks like Instagram is storing the photos at a maximum of 1080×1350 on its servers."